### PR TITLE
Add the first rule for GPU: Page Count 

### DIFF
--- a/src/parquet-linter-cli/src/main.rs
+++ b/src/parquet-linter-cli/src/main.rs
@@ -22,6 +22,9 @@ struct Cli {
     /// Only run specific rules (comma-separated)
     #[arg(long, value_delimiter = ',')]
     rules: Option<Vec<String>>,
+    /// Enable GPU-specific lint checks
+    #[arg(long = "GPU")]
+    gpu: bool,
     /// Minimum severity to display
     #[arg(long)]
     severity: Option<Severity>,
@@ -92,9 +95,12 @@ async fn main() -> Result<()> {
             let severity = cli.severity.unwrap_or(Severity::Suggestion);
             let rules = cli.rules;
             let export_prescription = cli.export_prescription;
+            let lint_options = parquet_linter::LintOptions { gpu: cli.gpu };
 
             let (store, path) = parquet_linter::loader::parse(&file)?;
-            let diagnostics = parquet_linter::lint(store, path, rules.as_deref()).await?;
+            let diagnostics =
+                parquet_linter::lint_with_options(store, path, rules.as_deref(), lint_options)
+                    .await?;
             let filtered: Vec<_> = diagnostics
                 .iter()
                 .filter(|d| d.severity >= severity)
@@ -184,8 +190,13 @@ async fn main() -> Result<()> {
                 }
             } else {
                 let (store, path) = parquet_linter::loader::parse(&file)?;
-                let diagnostics =
-                    parquet_linter::lint(store.clone(), path.clone(), rules.as_deref()).await?;
+                let diagnostics = parquet_linter::lint_with_options(
+                    store.clone(),
+                    path.clone(),
+                    rules.as_deref(),
+                    parquet_linter::LintOptions { gpu: cli.gpu },
+                )
+                .await?;
                 let mut prescription = Prescription::new();
                 for diagnostic in &diagnostics {
                     prescription.extend(diagnostic.prescription.clone());

--- a/src/parquet-linter-cli/src/main.rs
+++ b/src/parquet-linter-cli/src/main.rs
@@ -99,8 +99,7 @@ async fn main() -> Result<()> {
 
             let (store, path) = parquet_linter::loader::parse(&file)?;
             let diagnostics =
-                parquet_linter::lint_with_options(store, path, rules.as_deref(), lint_options)
-                    .await?;
+                parquet_linter::lint(store, path, rules.as_deref(), lint_options).await?;
             let filtered: Vec<_> = diagnostics
                 .iter()
                 .filter(|d| d.severity >= severity)
@@ -190,7 +189,7 @@ async fn main() -> Result<()> {
                 }
             } else {
                 let (store, path) = parquet_linter::loader::parse(&file)?;
-                let diagnostics = parquet_linter::lint_with_options(
+                let diagnostics = parquet_linter::lint(
                     store.clone(),
                     path.clone(),
                     rules.as_deref(),

--- a/src/parquet-linter-leaderboard/src/main.rs
+++ b/src/parquet-linter-leaderboard/src/main.rs
@@ -319,7 +319,13 @@ async fn lint_local_file(path: &Path) -> Result<Vec<parquet_linter::diagnostic::
         path.to_str()
             .ok_or_else(|| anyhow::anyhow!("non-utf8 path: {}", path.display()))?,
     )?;
-    parquet_linter::lint(store, object_path, None).await
+    parquet_linter::lint(
+        store,
+        object_path,
+        None,
+        parquet_linter::LintOptions::default(),
+    )
+    .await
 }
 
 fn validate_schema_match(original_path: &Path, rewritten_path: &Path) -> Result<()> {

--- a/src/parquet-linter/src/lib.rs
+++ b/src/parquet-linter/src/lib.rs
@@ -45,7 +45,8 @@ async fn lint_reader(
 ) -> anyhow::Result<Vec<Diagnostic>> {
     use parquet::arrow::async_reader::AsyncFileReader;
     let metadata = if options.gpu {
-        let arrow_options = parquet::arrow::arrow_reader::ArrowReaderOptions::new().with_page_index(true);
+        let arrow_options =
+            parquet::arrow::arrow_reader::ArrowReaderOptions::new().with_page_index(true);
         reader.clone().get_metadata(Some(&arrow_options)).await?
     } else {
         reader.clone().get_metadata(None).await?

--- a/src/parquet-linter/src/lib.rs
+++ b/src/parquet-linter/src/lib.rs
@@ -24,14 +24,6 @@ pub async fn lint(
     store: Arc<dyn ObjectStore>,
     path: ObjectPath,
     rule_names: Option<&[String]>,
-) -> anyhow::Result<Vec<Diagnostic>> {
-    lint_with_options(store, path, rule_names, LintOptions::default()).await
-}
-
-pub async fn lint_with_options(
-    store: Arc<dyn ObjectStore>,
-    path: ObjectPath,
-    rule_names: Option<&[String]>,
     options: LintOptions,
 ) -> anyhow::Result<Vec<Diagnostic>> {
     let reader = ParquetObjectReader::new(store, path);

--- a/src/parquet-linter/src/lib.rs
+++ b/src/parquet-linter/src/lib.rs
@@ -15,26 +15,47 @@ use object_store::path::Path as ObjectPath;
 use parquet::arrow::async_reader::ParquetObjectReader;
 use rule::RuleContext;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LintOptions {
+    pub gpu: bool,
+}
+
 pub async fn lint(
     store: Arc<dyn ObjectStore>,
     path: ObjectPath,
     rule_names: Option<&[String]>,
 ) -> anyhow::Result<Vec<Diagnostic>> {
+    lint_with_options(store, path, rule_names, LintOptions::default()).await
+}
+
+pub async fn lint_with_options(
+    store: Arc<dyn ObjectStore>,
+    path: ObjectPath,
+    rule_names: Option<&[String]>,
+    options: LintOptions,
+) -> anyhow::Result<Vec<Diagnostic>> {
     let reader = ParquetObjectReader::new(store, path);
-    lint_reader(reader, rule_names).await
+    lint_reader(reader, rule_names, options).await
 }
 
 async fn lint_reader(
     reader: ParquetObjectReader,
     rule_names: Option<&[String]>,
+    options: LintOptions,
 ) -> anyhow::Result<Vec<Diagnostic>> {
     use parquet::arrow::async_reader::AsyncFileReader;
-    let metadata = reader.clone().get_metadata(None).await?;
+    let metadata = if options.gpu {
+        let arrow_options = parquet::arrow::arrow_reader::ArrowReaderOptions::new().with_page_index(true);
+        reader.clone().get_metadata(Some(&arrow_options)).await?
+    } else {
+        reader.clone().get_metadata(None).await?
+    };
     let columns = column_context::build(&reader, &metadata).await?;
     let ctx = RuleContext {
         metadata,
         columns,
         reader,
+        gpu: options.gpu,
     };
     let rules = rules::get_rules(rule_names);
     let mut diagnostics: Vec<Diagnostic> = Vec::new();

--- a/src/parquet-linter/src/rule.rs
+++ b/src/parquet-linter/src/rule.rs
@@ -13,6 +13,7 @@ pub struct RuleContext {
     pub metadata: Arc<ParquetMetaData>,
     pub columns: Vec<ColumnContext>,
     pub reader: ParquetObjectReader,
+    pub gpu: bool,
 }
 
 #[async_trait::async_trait]

--- a/src/parquet-linter/src/rules/gpu_page_count.rs
+++ b/src/parquet-linter/src/rules/gpu_page_count.rs
@@ -1,0 +1,216 @@
+use parquet::column::page::PageReader;
+use parquet::schema::types::ColumnPath;
+
+use crate::diagnostic::{Diagnostic, Location, Severity};
+use crate::prescription::Prescription;
+use crate::rule::{self, Rule, RuleContext};
+
+pub struct GpuPageCountRule;
+
+const RECOMMENDED_PAGES_PER_ROW_GROUP: usize = 100;
+
+#[derive(Clone, Copy)]
+struct RowGroupPageCount {
+    total_pages: usize,
+    non_empty_columns: usize,
+}
+
+struct ColumnPageCount {
+    col_idx: usize,
+    path: ColumnPath,
+    pages: usize,
+}
+
+struct ColumnPageAggregate {
+    path: ColumnPath,
+    total_pages: usize,
+    non_empty_row_groups: usize,
+}
+
+async fn row_group_column_page_counts(
+    ctx: &RuleContext,
+    row_group_idx: usize,
+) -> Option<Vec<ColumnPageCount>> {
+    let row_group = ctx.metadata.row_group(row_group_idx);
+
+    // Fast path: use page locations from offset index when the file has page index metadata.
+    if let Some(offset_index) = ctx.metadata.offset_index() {
+        let mut counts = Vec::new();
+        for col_idx in 0..row_group.num_columns() {
+            let col = row_group.column(col_idx);
+            if col.num_values() == 0 {
+                continue;
+            }
+            let mut pages = offset_index[row_group_idx][col_idx].page_locations().len();
+            if col.dictionary_page_offset().is_some() {
+                pages += 1;
+            }
+            counts.push(ColumnPageCount {
+                col_idx,
+                path: col.column_path().clone(),
+                pages,
+            });
+        }
+        return Some(counts);
+    }
+
+    let mut counts = Vec::new();
+    // Fallback: scan pages in each column chunk when offset index is unavailable.
+    for col_idx in 0..row_group.num_columns() {
+        let col = row_group.column(col_idx);
+        if col.num_values() == 0 {
+            continue;
+        }
+
+        let mut pages = 0usize;
+        let mut page_reader =
+            rule::column_page_reader(&ctx.reader, &ctx.metadata, row_group_idx, col_idx)
+                .await
+                .ok()?;
+        while let Ok(Some(_page)) = page_reader.get_next_page() {
+            pages += 1;
+        }
+        counts.push(ColumnPageCount {
+            col_idx,
+            path: col.column_path().clone(),
+            pages,
+        });
+    }
+    Some(counts)
+}
+
+#[async_trait::async_trait]
+impl Rule for GpuPageCountRule {
+    fn name(&self) -> &'static str {
+        "gpu-row-group-page-count"
+    }
+
+    async fn check(&self, ctx: &RuleContext) -> Vec<Diagnostic> {
+        if !ctx.gpu {
+            return Vec::new();
+        }
+
+        let total_row_groups = ctx.metadata.num_row_groups();
+        let mut first_bad: Option<(usize, RowGroupPageCount)> = None;
+        let mut column_aggregates: Vec<Option<ColumnPageAggregate>> = Vec::new();
+        let mut read_failed_row_groups = 0usize;
+
+        for rg_idx in 0..total_row_groups {
+            let row_group = ctx.metadata.row_group(rg_idx);
+            if row_group.num_rows() <= 0 {
+                continue;
+            }
+
+            let Some(column_counts) = row_group_column_page_counts(ctx, rg_idx).await else {
+                read_failed_row_groups += 1;
+                continue;
+            };
+            if column_aggregates.is_empty() {
+                column_aggregates.resize_with(row_group.num_columns(), || None);
+            }
+
+            let mut page_count = RowGroupPageCount {
+                total_pages: 0,
+                non_empty_columns: 0,
+            };
+            // Aggregate column page counts across row groups so warnings can be emitted per column.
+            for column in column_counts {
+                page_count.total_pages += column.pages;
+                page_count.non_empty_columns += 1;
+
+                let slot = &mut column_aggregates[column.col_idx];
+                match slot {
+                    Some(agg) => {
+                        agg.total_pages += column.pages;
+                        agg.non_empty_row_groups += 1;
+                    }
+                    None => {
+                        *slot = Some(ColumnPageAggregate {
+                            path: column.path,
+                            total_pages: column.pages,
+                            non_empty_row_groups: 1,
+                        });
+                    }
+                }
+            }
+
+            if page_count.total_pages >= RECOMMENDED_PAGES_PER_ROW_GROUP {
+                continue;
+            }
+
+            if first_bad.is_none() {
+                first_bad = Some((rg_idx, page_count));
+            }
+        }
+
+        let Some((first_bad_idx, first_bad)) = first_bad else {
+            if read_failed_row_groups > 0 {
+                return vec![Diagnostic {
+                    rule_name: self.name(),
+                    severity: Severity::Warning,
+                    location: Location::File,
+                    message: format!(
+                        "GPU page-count check could not read page counts for {read_failed_row_groups} row group(s); results may be incomplete"
+                    ),
+                    prescription: Prescription::new(),
+                }];
+            }
+            return Vec::new();
+        };
+
+        let mut diagnostics = Vec::new();
+
+        for (col_idx, aggregate) in column_aggregates.into_iter().enumerate() {
+            if let Some(aggregate) = aggregate {
+                let avg_pages =
+                    aggregate.total_pages as f64 / aggregate.non_empty_row_groups.max(1) as f64;
+                diagnostics.push(Diagnostic {
+                    rule_name: self.name(),
+                    severity: Severity::Warning,
+                    location: Location::Column {
+                        column: col_idx,
+                        path: aggregate.path.clone(),
+                    },
+                    message: format!(
+                        "page count detail: this column averages {:.1} pages per non-empty row group ({} total pages across {}/{} row groups); for GPU scans, Parquet is recommended to have more than {} pages in each row group",
+                        avg_pages,
+                        aggregate.total_pages,
+                        aggregate.non_empty_row_groups,
+                        total_row_groups,
+                        RECOMMENDED_PAGES_PER_ROW_GROUP
+                    ),
+                    prescription: Prescription::new(),
+                });
+            }
+        }
+
+        if diagnostics.is_empty() {
+            diagnostics.push(Diagnostic {
+                rule_name: self.name(),
+                severity: Severity::Warning,
+                location: Location::RowGroup {
+                    index: first_bad_idx,
+                },
+                message: format!(
+                    "page count check failed for row_group[{first_bad_idx}] ({} total pages across {} non-empty column chunks); column averages unavailable",
+                    first_bad.total_pages, first_bad.non_empty_columns
+                ),
+                prescription: Prescription::new(),
+            });
+        }
+
+        if read_failed_row_groups > 0 {
+            diagnostics.push(Diagnostic {
+                rule_name: self.name(),
+                severity: Severity::Warning,
+                location: Location::File,
+                message: format!(
+                    "page count check could not read page counts for {read_failed_row_groups} row groups; column averages may be incomplete"
+                ),
+                prescription: Prescription::new(),
+            });
+        }
+
+        diagnostics
+    }
+}

--- a/src/parquet-linter/src/rules/gpu_page_count.rs
+++ b/src/parquet-linter/src/rules/gpu_page_count.rs
@@ -82,7 +82,7 @@ async fn row_group_column_page_counts(
 #[async_trait::async_trait]
 impl Rule for GpuPageCountRule {
     fn name(&self) -> &'static str {
-        "gpu-row-group-page-count"
+        "gpu-page-count"
     }
 
     async fn check(&self, ctx: &RuleContext) -> Vec<Diagnostic> {
@@ -113,7 +113,7 @@ impl Rule for GpuPageCountRule {
                 total_pages: 0,
                 non_empty_columns: 0,
             };
-            // Aggregate column page counts across row groups so warnings can be emitted per column.
+            // Aggregate column page counts across row groups.
             for column in column_counts {
                 page_count.total_pages += column.pages;
                 page_count.non_empty_columns += 1;
@@ -150,7 +150,7 @@ impl Rule for GpuPageCountRule {
                     severity: Severity::Warning,
                     location: Location::File,
                     message: format!(
-                        "GPU page-count check could not read page counts for {read_failed_row_groups} row group(s); results may be incomplete"
+                        "page count check could not read page counts for {read_failed_row_groups} row groups; results may be incomplete"
                     ),
                     prescription: Prescription::new(),
                 }];

--- a/src/parquet-linter/src/rules/mod.rs
+++ b/src/parquet-linter/src/rules/mod.rs
@@ -2,6 +2,7 @@ mod compression_codec;
 mod compression_ratio;
 mod dictionary_encoding;
 mod float_encoding;
+mod gpu_page_count;
 mod page_size;
 mod page_statistics;
 mod string_encoding;
@@ -19,6 +20,7 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(dictionary_encoding::DictionaryEncodingRule),
         Box::new(page_size::PageSizeRule),
         Box::new(float_encoding::FloatEncodingRule),
+        Box::new(gpu_page_count::GpuPageCountRule),
         Box::new(string_encoding::StringEncodingRule),
         Box::new(compression_codec::CompressionCodecRule),
         Box::new(timestamp_encoding::TimestampEncodingRule),


### PR DESCRIPTION
Hi Xiangpeng,

This is the first rule I’ve drafted specifically for the cuDF GPU Parquet reader. The rule checks the average page count from all RGs in each column, which should be greater than 100 due to cuDF’s internal parallelism design. In practice, Parquet files with extremely low page counts, e.g., 1, can lead to long runtimes and underutilized GPUs. Users may then blame cuDF or the GPU, without realizing that the file itself is poorly configured.

I have no  “fix” and thus no prescription for this rule yet, since it’s not directly available to set page counts. In my own rewriter, I address this by adjusting the row count in RG and page to ensure that each RG contains more than 100 pages.

---

Below are some runs and timings on SF3 lineitem:
```
$ time ./target/release/parquet-linter /tmp/lineitem.parquet 
...
16 issue(s) found.
./target/release/parquet-linter /tmp/lineitem.parquet  0.04s user 0.03s system 97% cpu 0.063 total

$ time ./target/release/parquet-linter --GPU /tmp/lineitem.parquet 
...
warning gpu-page-count
  --> column[14]("l_shipmode")
  page count detail: this column averages 2.0 pages per non-empty row group (294 total pages across 147/147 row groups); for GPU scans, Parquet is recommended to have more than 100 pages in each row group
31 issue(s) found.
./target/release/parquet-linter --GPU /tmp/lineitem.parquet  1.80s user 0.24s system 98% cpu 2.074 total
```
The `--GPU` flag is optional and enables GPU-specific rule and warnings. Runtime can also improve significantly if the file has page offsets.